### PR TITLE
Login redirect page now displays an error only when there is one.

### DIFF
--- a/src/components/Authenticate/Authenticate.tsx
+++ b/src/components/Authenticate/Authenticate.tsx
@@ -1,21 +1,22 @@
 import React, { useEffect, useState } from "react";
 import {spotify} from "../../data/auth_parameters";
-import { Access, Error } from "../../data/types";
-import { getSpotifyStorage, setSpotifyStorage } from "../../helpers/token";
+import { Access, ErrorBox } from "../../data/types";
+import { refreshSpotifyStorage, setSpotifyStorage } from "../../helpers/token";
+import { getState } from "../../helpers/state";
 
-type LoginProps = {
-    toYouTube: boolean
-    state: string
+type Props = {
+    toYouTube: boolean, 
+    enabled: boolean
 };
 
-export function SpotifyLogin(props: LoginProps){
+export function SpotifyLogin(props: Props){
 
     const buildLink = 
         `${spotify.auth_endpoint}`+
         `client_id=${spotify.client_id}&`+
         `response_type=code&`+
         `redirect_uri=${spotify.redirect_uri}&`+
-        `state=${props.state}&`+
+        `state=${getState()}&`+
         `scope=${
             spotify.scopes.reduce((x, y) => {return `${x}%20${y}`;}, "")
             .substring(3)
@@ -24,12 +25,12 @@ export function SpotifyLogin(props: LoginProps){
     const [loggedIn, setLoggedIn] = useState<boolean>(false);
     const [loaded, setLoaded] = useState(false);
     const getLoggedIn = async () => {
-        const access: Access | Error = await getSpotifyStorage();
+        const access: Access | ErrorBox = await refreshSpotifyStorage();
         if(access.hasOwnProperty("access_token")){
             setLoggedIn(true);
             setSpotifyStorage(access as Access);
         }else{
-            const accessError: Error = access as Error;
+            const accessError: ErrorBox = access as ErrorBox;
             console.log(accessError);
             setLoggedIn(false);
         }
@@ -39,7 +40,7 @@ export function SpotifyLogin(props: LoginProps){
 
     useEffect(() => {
         getLoggedIn();
-    });
+    }, [loggedIn, loaded, props]);
 
     return(
         <>
@@ -48,7 +49,7 @@ export function SpotifyLogin(props: LoginProps){
             ?   
                 loggedIn 
                 ? <p>Logged into Spotify!</p>
-                : <a href={buildLink}>Log into Spotify</a>
+                : <p><a href={buildLink}>Log into Spotify</a></p>
             : <p>Trying to log you in...</p>
             }
         </>

--- a/src/components/DestinationDropdown/DestinationDropdown.tsx
+++ b/src/components/DestinationDropdown/DestinationDropdown.tsx
@@ -4,7 +4,7 @@ import DropdownButton from 'react-bootstrap/DropdownButton';
 
 type Props = {
     toYouTube: boolean, 
-    changeDirection: (d: boolean) => void
+    setToYouTube: (d: boolean) => void
 };
 
 type State = {
@@ -21,7 +21,7 @@ export class DestinationDropdown extends React.Component<Props, State>{
     }
 
     select(toYouTube: boolean): void{
-        this.props.changeDirection(toYouTube);
+        this.props.setToYouTube(toYouTube);
         this.setState({text: toYouTube ? "YouTube" : "Spotify"});
     }
 

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -4,4 +4,12 @@ export type Access = {
     refresh_token: string
 }
 
-export type Error = { error: string }
+export type AccessCode = {
+    access_code: string
+}
+
+export type ErrorBox = { error: string }
+
+export const isErrorOrUndefined = (x: any): boolean => {
+    return x === undefined || x === null || 'error' in x;
+}

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -1,0 +1,4 @@
+export function forget(): void{
+    localStorage.clear();
+    console.log("localStorage cleared");
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -3,11 +3,13 @@ import "./Home.scss";
 import {Container} from '../../components/Container/Container';
 import {SpotifyLogin} from '../../components/Authenticate/Authenticate';
 import {DestinationDropdown} from '../../components/DestinationDropdown/DestinationDropdown';
-import {spotify} from '../../data/auth_parameters';
+import Button from 'react-bootstrap/Button';
+import { isValidSpotifyStorage } from '../../helpers/token';
+import { forget } from '../../helpers/storage';
 
 type State = {
     toYouTube: boolean,
-    spotifyState: string
+    enabled: boolean
 }
 
 export class Home extends React.Component<{}, State>{
@@ -15,13 +17,23 @@ export class Home extends React.Component<{}, State>{
         super(props);
         this.state = {
             toYouTube: true,
-            spotifyState: spotify.state
+            enabled: isValidSpotifyStorage()
         }
-        this.changeDirection = this.changeDirection.bind(this);
+        this.setToYouTube = this.setToYouTube.bind(this);
+        this.setEnabled = this.setEnabled.bind(this);
     }
 
-    changeDirection(d: boolean){
-        this.setState({toYouTube: d});
+    setToYouTube(d: boolean){
+        this.setState({toYouTube: d, enabled: this.state.enabled});
+    }
+
+    forgetSet(){
+        forget();
+        this.setEnabled(isValidSpotifyStorage());
+    }
+
+    setEnabled(d: boolean){
+        this.setState({toYouTube: this.state.toYouTube, enabled: d});
     }
 
     render(){
@@ -29,9 +41,14 @@ export class Home extends React.Component<{}, State>{
             <Container>
                 <div className="write-select">
                     <h3>Writing to</h3>
-                    <DestinationDropdown toYouTube={this.state.toYouTube} changeDirection={this.changeDirection}/>
+                    <DestinationDropdown toYouTube={this.state.toYouTube} setToYouTube={this.setToYouTube}/>
                 </div>
-                <SpotifyLogin toYouTube={this.state.toYouTube} state={this.state.spotifyState}/>
+                <SpotifyLogin toYouTube={this.state.toYouTube} enabled={this.state.enabled}/>
+                {   
+                    isValidSpotifyStorage() 
+                    ? <Button type="button" className="btn btn-warning" onClick={() => {this.forgetSet();}}>Forget me</Button>
+                    : <Button type="button" className="btn btn-warning" disabled>Forget me</Button>
+                }
             </Container>
         )
     }

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -2,19 +2,18 @@ import React, { useState, useEffect } from "react";
 import { Container } from "react-bootstrap";
 import { Link, useLocation } from "react-router-dom";
 import { spotify } from "../../data/auth_parameters";
-import { getCurrentSecondsFloor, setSpotifyStorage } from "../../helpers/token";
-import { Access, Error } from "../../data/types";
+import { getCurrentSecondsFloor, setSpotifyStorage, isValidSpotifyStorage } from "../../helpers/token";
+import { Access, ErrorBox } from "../../data/types";
 
-//avoid hook loop by making consistent objects
-const codeError: Error = { error: "Awaiting code retrieval..." }
-const accessError: Error = { error: "Awaiting access code..." };
+const accessError: ErrorBox = {error: "getAccess() has not run"};
+const empty: {} = {};
 
 export function Login(){
 
-    const [code, setCode] = useState<string | Error>(codeError);
-    const [access, setAccess] = useState<Access | Error>(accessError);
+    const [access, setAccess] = useState<Access | ErrorBox | {}>(empty);
+    const [fetched, setFetched] = useState<boolean>(false);
 
-    const getCode = (): void => {
+    const getCode = async (): Promise<string | null> => {
         console.log("running getCode");
         const params: string = window.location.href;
         const stateRE = new RegExp('state=(.+)')
@@ -23,66 +22,71 @@ export function Login(){
         const codeArr: RegExpExecArray | null = codeRE.exec(params);
         const state: string | null = stateArr === null ? null : stateArr[1];
         const codeRead: string | null = codeArr === null ? null : codeArr[1];
-        if(state === null || codeRead === null || state === "" || codeRead === ""){
-            codeError.error = "Malformed URI";
-            setCode(codeError);
-        }else if(state !== spotify.state){
-            codeError.error = "Inconsistent state";
-            setCode(codeError);
-        }else{
-            setCode(codeRead);
-        }
-        console.log(code);
+        if(state === null || state === "") return Promise.reject(new Error("state is null"));
+        if(state !== spotify.state) return Promise.reject(new Error("state is inconsistent"));
+        return codeRead;
     }
-    
-    const buildURL = (): string => {
+
+    const buildURL = (code: string): string => {
         const url: string = `${spotify.backend_endpoint}` +
             `${spotify.access_token_endpoint}`+
             `code=${code}&`+
             `redirect_uri=${spotify.redirect_uri}&`+
             `client_id=${spotify.client_id}`;
-        console.log(url);
         return url;
     }
 
-    const fetchAccessToken = async () => {
-        console.log("fetching access token...");
-        if(code !== codeError){
-            const url: string = buildURL();
-            const response = await fetch(url);
-            //console.log(response);
-            if(!response.ok) { 
-                accessError.error = `Tried to fetch ${url}, got code: ${response.status}; response: ${response.text}`;
-                setAccess(accessError);
-            }else{
-                //successfully recieved access and refresh tokens
-                const access: Access = await response.json();
-                access.expires_in += getCurrentSecondsFloor();
-                setAccess(access);
-                setSpotifyStorage(access);
-            }
-        }else{
-            accessError.error = `Awaiting access code...`;
+    const fetchAccessToken = async (c: string) => {
+        console.log(`fetching access token...`);
+        const url: string = buildURL(c);
+        const response = await fetch(url);
+        setFetched(true);
+        //console.log(response);
+        if(!response.ok) { 
+            accessError.error = `Tried to fetch ${url}, got code: ${response.status}; response: ${await response.text()}`;
             setAccess(accessError);
+            Promise.reject(Error(accessError.error));
+        }else{
+            //successfully recieved access and refresh tokens
+            const access: Access = await response.json();
+            access.expires_in += getCurrentSecondsFloor();
+            setAccess(access);
+            setSpotifyStorage(access);
         }
     }
 
+    const getThenFetch = async () => {
+        getCode().then((c: string | null) => {
+            if(c !== null && fetched === false && access === empty) { 
+                fetchAccessToken(c);
+            }else if(fetched === true) {
+                return Promise.reject(Error("already fetched"));
+            }
+            else {
+                return Promise.reject(Error("code is null")); 
+            }
+            return;
+        }, (error) => { console.error(error); }).then(
+            () => {},
+            (error) => { console.error(error); }
+        )
+    }
+
     useEffect(() => {
-        getCode();
-        if(access === accessError) fetchAccessToken();
-        console.log(access);
-    }, [code, codeError, accessError, access]);
+        getThenFetch();
+    }, []);
 
     return(
         <Container>
             <h2>Spotify</h2>
-            {access === accessError ? 
-                <>
-                    {code === codeError ? <p>{`Error: ${code.error}`}</p> : <></>}
-                    <p>{`Error: ${access.error}`}</p>
-                </> 
-                : 
-                <p>Logged in</p>}
+            {!isValidSpotifyStorage()
+                ? 'error' in access 
+                    ? <p>Error: {access.error}</p>
+                    : <p>Erorr: Invalid spotify Storage</p>
+                : (access === empty) 
+                    ? <p>Error: access is empty</p>
+                    : <p>Logged in</p>
+            }
             <Link to="/">{`< Go back`}</Link>
         </Container>
     )


### PR DESCRIPTION
# Changes
## ``Login.tsx``
- Simplified hooked access token fetch function
- Included a proper promise chain with error capture
- Async function run more than once by ``useEffect`` hook? LocalStorage is checked to be invalid before an error is presented. 
## ``Authenticate.tsx``
- Given enabled prop from Home 
- State now fetched through helper function ``getState()`` for guaranteed accuracy (used to fail first time user logged in)
## ``types.ts``
- Renamed ``Error`` to ``ErrorBox`` avoiding namespace collision between ``Promise.reject(Error(""))``.
# Additions 
## ``storage.ts`` helper
- Contains generic storage functions, like ``forget()`` which clears localStorage